### PR TITLE
refactor: :recycle: disable bash shell link when container not running

### DIFF
--- a/frontend/src/components/Container.vue
+++ b/frontend/src/components/Container.vue
@@ -15,8 +15,8 @@
                 </div>
             </div>
             <div class="col-5">
-                <div class="function">
-                    <router-link v-if="!isEditMode" class="btn btn-normal" :to="terminalRouteLink" disabled="">
+                <div class="function" :class="{notallowed:!(!isEditMode && active)}">
+                    <router-link v-if="!isEditMode" class="btn btn-normal" :to="terminalRouteLink" :class="{disabledlink:!(!isEditMode && active)}">
                         <font-awesome-icon icon="terminal" />
                         Bash
                     </router-link>
@@ -159,7 +159,11 @@ export default defineComponent({
         status: {
             type: String,
             default: "N/A",
-        }
+        },
+        active: {
+            type: Boolean,
+            default: false,
+        },
     },
     emits: [
     ],
@@ -308,5 +312,16 @@ export default defineComponent({
         align-items: center;
         justify-content: end;
     }
+}
+
+.disabledlink {
+    pointer-events: none;
+    border: 1px solid #999999;
+    background-color: #cccccc;
+    color: #666666;
+}
+
+.notallowed{
+    cursor: not-allowed;
 }
 </style>

--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -129,6 +129,7 @@
                             :is-edit-mode="isEditMode"
                             :first="name === Object.keys(jsonConfig.services)[0]"
                             :status="serviceStatusList[name]"
+                            :active="active"
                         />
                     </div>
 


### PR DESCRIPTION
> ⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules: https://github.com/louislam/dockge/blob/master/CONTRIBUTING.md
> 
> Tick the checkbox if you understand [x]:
> 
>     * [x]  I have read and understand the pull request rules.
> 
> 
> # Description
> 
> refactor open bash in a container, when the container is not running user can open bash then he see the message error `service "x" is not running`, so he returns to run or start the container so, I make `open bash link` disable until the container is running
> 
> Fixes #(issue)
> ## Type of change
> 
>     * Add class condition to bash part which makes it disabled & not-allowed cursor
> 
> 
> Please delete any options that are not relevant.
> 
>     * Bug fix (non-breaking change which fixes an issue)
> 
>     * User interface (UI)
> 
>     * New feature (non-breaking change which adds functionality)
> 
>     * Breaking change (fix or feature that would cause existing functionality to not work as expected)
> 
>     * Other
> 
>     * This change requires a documentation update
> 
> 
> ## Checklist
> 
>     * [x]  My code follows the style guidelines of this project
> 
>     * [x]  I ran ESLint and other linters for modified files
> 
>     * [x]  I have performed a self-review of my own code and tested it
> 
>     * [ ]  I have commented my code, particularly in hard-to-understand areas
>       (including JSDoc for methods)
> 
>     * [x]  My changes generate no new warnings
> 
>     * [ ]  My code needed automated testing. I have added them (this is optional task)
> 
> 
> ## Screenshots (if any)
> 
> ![Screenshot from 2024-03-20 21-53-04-fotor-20240320215811](https://private-user-images.githubusercontent.com/63800183/314654566-daf08a43-2d3f-4399-b637-5e3f74e5bb62.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDkxNzkxMzgsIm5iZiI6MTc0OTE3ODgzOCwicGF0aCI6Ii82MzgwMDE4My8zMTQ2NTQ1NjYtZGFmMDhhNDMtMmQzZi00Mzk5LWI2MzctNWUzZjc0ZTViYjYyLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA2MDYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNjA2VDAzMDAzOFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTBiMzFhNmVjNzVhOTUxMmI0OTFkMzU1MTU3MDdkYzllOTBlNDNjYmViNzFiMDJmNGRiNjE0MGJkZDE0ZjY5YzAmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.z0fF9SKSSL4rHvBkIvZCVDF39pcZD0J_JK7HPSeo2zY)
> 
> Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.

